### PR TITLE
Added support for MQTT Client ID

### DIFF
--- a/GUI/Broker.py
+++ b/GUI/Broker.py
@@ -1,5 +1,7 @@
 from PyQt5.QtCore import QSettings, QDir
 from PyQt5.QtWidgets import QDialog, QLineEdit, QFormLayout, QPushButton, QGroupBox, QCheckBox
+import random
+import string
 
 from GUI import SpinBox, HLayout, VLayout
 
@@ -33,6 +35,13 @@ class BrokerDialog(QDialog):
         lfl.addRow("Password", self.password)
         gbLogin.setLayout(lfl)
 
+        gbClientId = QGroupBox("Client ID [optional]")
+        cfl = QFormLayout()
+        self.clientId = QLineEdit()
+        self.clientId.setText(self.settings.value("client_id", "tdm-" + self.random_generator()))
+        cfl.addRow("Client ID", self.clientId)
+        gbClientId.setLayout(cfl)
+
         self.cbConnectStartup = QCheckBox("Connect on startup")
         self.cbConnectStartup.setChecked(self.settings.value("connect_on_startup", False, bool))
 
@@ -42,7 +51,7 @@ class BrokerDialog(QDialog):
         hlBtn.addWidgets([btnSave, btnCancel])
 
         vl = VLayout()
-        vl.addWidgets([gbHost, gbLogin, self.cbConnectStartup])
+        vl.addWidgets([gbHost, gbLogin, gbClientId, self.cbConnectStartup])
         vl.addLayout(hlBtn)
 
         self.setLayout(vl)
@@ -56,5 +65,11 @@ class BrokerDialog(QDialog):
         self.settings.setValue("username", self.username.text())
         self.settings.setValue("password", self.password.text())
         self.settings.setValue("connect_on_startup", self.cbConnectStartup.isChecked())
+        self.settings.setValue("client_id", self.clientId.text())
         self.settings.sync()
         self.done(QDialog.Accepted)
+
+    ##################################################################
+    # utils
+    def random_generator(self, size=6, chars=string.ascii_uppercase + string.digits):
+        return ''.join(random.choice(chars) for x in range(size))

--- a/tdm.py
+++ b/tdm.py
@@ -189,16 +189,7 @@ class MainWindow(QMainWindow):
 
     def toggle_connect(self, state):
         if state and self.mqtt.state == self.mqtt.Disconnected:
-            self.broker_hostname = self.settings.value('hostname', 'localhost')
-            self.broker_port = self.settings.value('port', 1883, int)
-            self.broker_username = self.settings.value('username')
-            self.broker_password = self.settings.value('password')
-
-            self.mqtt.hostname = self.broker_hostname
-            self.mqtt.port = self.broker_port
-
-            if self.broker_username:
-                self.mqtt.setAuth(self.broker_username, self.broker_password)
+            self.mqtt_connect_perform()
             self.mqtt.connectToHost()
         elif not state and self.mqtt.state == self.mqtt.Connected:
             self.mqtt_disconnect()
@@ -211,19 +202,26 @@ class MainWindow(QMainWindow):
                 self.mqtt.publish(cmnd+"STATUS", payload=8)
 
     def mqtt_connect(self):
+        self.mqtt_connect_perform()
+        if self.mqtt.state == self.mqtt.Disconnected:
+            self.mqtt.connectToHost()
+
+    def mqtt_connect_perform(self):
         self.broker_hostname = self.settings.value('hostname', 'localhost')
         self.broker_port = self.settings.value('port', 1883, int)
         self.broker_username = self.settings.value('username')
         self.broker_password = self.settings.value('password')
+        self.broker_clientId = self.settings.value('client_id')
 
         self.mqtt.hostname = self.broker_hostname
         self.mqtt.port = self.broker_port
 
         if self.broker_username:
-            self.mqtt.setAuth(self.broker_username, self.broker_password)
+            self.mqtt.username = self.broker_username
+            self.mqtt.password = self.broker_password
+        if self.broker_clientId:
+            self.mqtt.clientId = self.broker_clientId
 
-        if self.mqtt.state == self.mqtt.Disconnected:
-            self.mqtt.connectToHost()
 
     def mqtt_disconnect(self):
         self.mqtt.disconnectFromHost()


### PR DESCRIPTION
Some configurations of MQTT Brokers require Client ID to have a certain
prefix in order to connect to them. This addresses that scenario.

By default client id is generated in a form of `tdm-XXXXXX`, where `XXXXXX` is a 6 character alpha-numeric string that is randomly generated.