### PR TITLE
Strip out double quotes from copied text.

### DIFF
--- a/GUI/Devices.py
+++ b/GUI/Devices.py
@@ -234,7 +234,10 @@ class ListWidget(QWidget):
 
     def ctx_menu_copy(self):
         if self.idx:
-            QApplication.clipboard().setText(dumps(self.model.data(self.idx)))
+            string = dumps(self.model.data(self.idx))
+            if string.startswith('"') and string.endswith('"'):
+                string = string[1:-1]
+            QApplication.clipboard().setText(string)
 
     def ctx_menu_clear_retained(self):
         if self.device:


### PR DESCRIPTION
I was getting annoyed that when I right click and copy (bssid for example) I get it in double-quotes...
So I changed the coding a little to strip out the quotes.
