### PR TITLE
adding a requirements file for pip -r

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-paho_mqtt
-PyQt5
-
+paho_mqtt>=1.4
+PyQt5>=5.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+paho_mqtt
+PyQt5
+


### PR DESCRIPTION
Suggesting a `requirements.txt` file to easily install dependencies in venv (pip -r)