### PR TITLE
Prevent crash on STATUS without Status key

### DIFF
--- a/Util/__init__.py
+++ b/Util/__init__.py
@@ -200,7 +200,7 @@ class TasmotaDevice(QObject):
                     logging.critical("PARSER: Can't parse STATUS (%s)", e)
 
                 if payload:
-                    payload = payload['Status']
+                    payload = payload.get('Status', None)
                     for k, v in payload.items():
                         if k == "FriendlyName":
                             for fnk, fnv in enumerate(v, start=1):

--- a/Util/__init__.py
+++ b/Util/__init__.py
@@ -200,7 +200,7 @@ class TasmotaDevice(QObject):
                     logging.critical("PARSER: Can't parse STATUS (%s)", e)
 
                 if payload:
-                    payload = payload.get('Status', None)
+                    payload = payload.get('Status', {})
                     for k, v in payload.items():
                         if k == "FriendlyName":
                             for fnk, fnv in enumerate(v, start=1):


### PR DESCRIPTION
There is 1 case where Tasmota may publish on stat/%topic%/STATUS a JSON which do not include a `Status` key. It is just before entering deep-sleep and if SetOption4 is ON.
The message is then `stat/tasmota/STATUS = {"DeepSleep":{"Time":"2019-11-12T21:33:45","Epoch":1573590825}}`
and `payload = payload['Status']` create an exception.

This change prevent the crash.

Note PR as been pushed to Tasmota but it will take time, if accepted, before this massively deployed. 