### PR TITLE
Fix for rule's JSON format changed in Tasmota 9.3.1.2

### DIFF
--- a/GUI/Rules.py
+++ b/GUI/Rules.py
@@ -209,7 +209,7 @@ class RulesWidget(QWidget):
 
     def select_rt(self, idx):
         self.rt = idx.row()
-        
+
     def set_rt(self, idx):
         curr = self.rts[self.rt]
         new, ok = QInputDialog.getInt(self, "Set ruletimer", "Set ruletimer{} value.".format(self.rt+1), value=curr)
@@ -217,12 +217,16 @@ class RulesWidget(QWidget):
             self.sendCommand.emit(self.device.cmnd_topic("ruletimer{}".format(self.rt+1)), str(new))
 
     def display_rule(self, payload, rule):
+            if type(payload[rule]) is dict:
+                payload = payload[rule]
+                self.actEnabled.setChecked(payload['State'] == "ON")
+            else:
+                self.actEnabled.setChecked(payload[rule] == "ON")
             rules = payload['Rules'].replace(" on ", "\non ").replace(" do ", " do\n\t").replace(" endon", "\nendon ").rstrip(" ")
             if len(rules) == 0:
                 self.editor.setPlaceholderText("rule buffer is empty")
             self.editor.setPlainText(rules)
 
-            self.actEnabled.setChecked(payload[rule] == "ON")
             self.actOnce.setChecked(payload['Once'] == 'ON')
             self.actStopOnError.setChecked(payload['StopOnError'] == 'ON')
 

--- a/Util/mqtt.py
+++ b/Util/mqtt.py
@@ -149,7 +149,7 @@ class MqttClient(QtCore.QObject):
             retained = msg.retain
             self.messageSignal.emit(topic, mstr, retained)
         except UnicodeDecodeError as e:
-            logging.error('MQTT MESSAGE DECODE ERROR: %s', e)
+            logging.error('MQTT MESSAGE DECODE ERROR: %s (%s=%s)', e, msg.topic,msg.payload.__repr__())
 
     def on_connect(self, *args):
         rc = args[3]


### PR DESCRIPTION
** Issue
TDM crash when opening the rule editor with Tasmota >=9.3.1.2 due to change in the JSON format (introducing an additional level in the object)

Tasmota commit : https://github.com/arendst/Tasmota/commit/403eba7a99b15d48f62f253ecf7adc29b1489131

** Fix
This fix checks if the JSON is flat or has the additional level and parse accordingly.
Doesn't break compatibility with older versions.

As an accessory, it also adds extended logs in case of JSON decode error (case of corrupted JSON)