### PR TITLE
Include CHANGELOG.md in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include CHANGELOG.md


### PR DESCRIPTION
I was packaging this for Arch Linux, and ran into this error:

```
Traceback (most recent call last):
  File "/home/user/dev/aur/tdmgr/src/tdmgr-0.2.11/setup.py", line 8, in <module>
    with open("CHANGELOG.md", "r") as clog:
FileNotFoundError: [Errno 2] No such file or directory: 'CHANGELOG.md'
```

The source distribution doesn't include `CHANGELOG.md` because it isn't in the list of stuff: https://packaging.python.org/guides/using-manifest-in/

Yuuuppp. Python packaging is a PITA and super easy to get wrong.