### PR TITLE
Added explicit cast to int for drawPixmap - Fixes #176 #184

### DIFF
--- a/GUI/Buttons.py
+++ b/GUI/Buttons.py
@@ -49,9 +49,6 @@ class ButtonsDialog(QDialog):
         btns.accepted.connect(self.accept)
         btns.rejected.connect(self.reject)
         vl.addWidgets(
-            [
-                HTMLLabel("<a href={}/Buttons-and-Switches>Buttons and Switches</a>".format(docs_url)),
-                btns,
-            ]
+            [HTMLLabel("<a href={}/Buttons-and-Switches>Buttons and Switches</a>".format(docs_url)), btns,]
         )
         self.setLayout(vl)

--- a/GUI/Console.py
+++ b/GUI/Console.py
@@ -79,14 +79,7 @@ class ConsoleWidget(QDockWidget):
 
         self.cbMQTTLog = QComboBox()
         self.cbMQTTLog.addItems(
-            [
-                "Disabled",
-                "Error",
-                "Error/Info (default)",
-                "Error/Info/Debug",
-                "Error/Info/More debug",
-                "All",
-            ]
+            ["Disabled", "Error", "Error/Info (default)", "Error/Info/Debug", "Error/Info/More debug", "All",]
         )
         mqttlog = self.device.p.get("MqttLog", -1)
 

--- a/GUI/Devices.py
+++ b/GUI/Devices.py
@@ -442,10 +442,7 @@ class ListWidget(QWidget):
     def configureOtaUrl(self):
         if self.device:
             url, ok = QInputDialog.getText(
-                self,
-                "Set OTA URL",
-                '100 chars max. Set to "1" to reset to default.',
-                text=self.device.p['OtaUrl'],
+                self, "Set OTA URL", '100 chars max. Set to "1" to reset to default.', text=self.device.p['OtaUrl'],
             )
             if ok:
                 self.mqtt.publish(self.device.cmnd_topic("otaurl"), payload=url)

--- a/GUI/Power.py
+++ b/GUI/Power.py
@@ -31,10 +31,7 @@ class PowerDialog(QDialog):
         self.ci = Interlock(
             "Interlock",
             commands["Interlock"],
-            {
-                "Interlock": self.device.p.get("Interlock", "OFF"),
-                "Groups": self.device.p.get("Groups", ""),
-            },
+            {"Interlock": self.device.p.get("Interlock", "OFF"), "Groups": self.device.p.get("Groups", ""),},
         )
         vl_cmd.addWidget(self.ci)
 
@@ -64,9 +61,6 @@ class PowerDialog(QDialog):
         btns.accepted.connect(self.accept)
         btns.rejected.connect(self.reject)
         vl.addWidgets(
-            [
-                HTMLLabel("<a href={}/Buttons-and-Switches>Buttons and Switches</a>".format(docs_url)),
-                btns,
-            ]
+            [HTMLLabel("<a href={}/Buttons-and-Switches>Buttons and Switches</a>".format(docs_url)), btns,]
         )
         self.setLayout(vl)

--- a/GUI/Switches.py
+++ b/GUI/Switches.py
@@ -53,9 +53,6 @@ class SwitchesDialog(QDialog):
         btns.accepted.connect(self.accept)
         btns.rejected.connect(self.reject)
         vl.addWidgets(
-            [
-                HTMLLabel("<a href={}/Buttons-and-Switches>Buttons and Switches</a>".format(docs_url)),
-                btns,
-            ]
+            [HTMLLabel("<a href={}/Buttons-and-Switches>Buttons and Switches</a>".format(docs_url)), btns,]
         )
         self.setLayout(vl)

--- a/GUI/Templates.py
+++ b/GUI/Templates.py
@@ -44,8 +44,7 @@ class TemplateDialog(QDialog):
                 gbx.setCurrentText(gpios.get(str(tpl['GPIO'][i])))
 
                 fl.addRow(
-                    "<font color='{}'>GPIO{}</font>".format('red' if g in [9, 10] else 'black', g),
-                    gbx,
+                    "<font color='{}'>GPIO{}</font>".format('red' if g in [9, 10] else 'black', g), gbx,
                 )
                 self.gb[i] = gbx
 

--- a/GUI/Timers.py
+++ b/GUI/Timers.py
@@ -177,8 +177,7 @@ class TimersDialog(QDialog):
                     desc['time'] = "at {}".format(time.toString("hh:mm"))
                 else:
                     desc['time'] = "somewhere between {} and {}".format(
-                        time.addSecs(wnd * -1).toString("hh:mm"),
-                        time.addSecs(wnd).toString("hh:mm"),
+                        time.addSecs(wnd * -1).toString("hh:mm"), time.addSecs(wnd).toString("hh:mm"),
                     )
             else:
                 prefix = "before" if pm == "-" else "after"

--- a/GUI/__init__.py
+++ b/GUI/__init__.py
@@ -24,41 +24,12 @@ base_view = ["Device"]
 default_views = {
     "Home": base_view + ["Module", "Power", "Color", "LoadAvg", "LinkCount", "Uptime"],
     "Health": base_view
-    + [
-        "Uptime",
-        "BootCount",
-        "RestartReason",
-        "LoadAvg",
-        "Sleep",
-        "MqttCount",
-        "LinkCount",
-        "Downtime",
-        "RSSI",
-    ],
+    + ["Uptime", "BootCount", "RestartReason", "LoadAvg", "Sleep", "MqttCount", "LinkCount", "Downtime", "RSSI",],
     "Firmware": base_view + ["Version", "Core", "SDK", "ProgramSize", "Free", "OtaUrl"],
     "Wifi": base_view
-    + [
-        "Hostname",
-        "Mac",
-        "IPAddress",
-        "Gateway",
-        "SSId",
-        "BSSId",
-        "Channel",
-        "RSSI",
-        "LinkCount",
-        "Downtime",
-    ],
+    + ["Hostname", "Mac", "IPAddress", "Gateway", "SSId", "BSSId", "Channel", "RSSI", "LinkCount", "Downtime",],
     "MQTT": base_view
-    + [
-        "Topic",
-        "FullTopic",
-        "CommandTopic",
-        "StatTopic",
-        "TeleTopic",
-        "FallbackTopic",
-        "GroupTopic",
-    ],
+    + ["Topic", "FullTopic", "CommandTopic", "StatTopic", "TeleTopic", "FallbackTopic", "GroupTopic",],
 }
 
 console_font = QFont("asd")
@@ -378,8 +349,7 @@ class CommandMultiSelect(QWidget):
             cb = QComboBox()
             for k, v in meta['parameters'].items():
                 cb.addItem(
-                    "{}: {} {}".format(k, v['description'], "(default)" if v.get("default") else ""),
-                    k,
+                    "{}: {} {}".format(k, v['description'], "(default)" if v.get("default") else ""), k,
                 )
             cb.setCurrentIndex(val)
             hl_input = HLayout(0)
@@ -420,8 +390,7 @@ class Interlock(QWidget):
         user_data = ["OFF", "ON"]
         for k, v in meta['parameters'].items():
             self.input.addItem(
-                "{} {}".format(v['description'], "(default)" if v.get("default") else ""),
-                user_data[int(k)],
+                "{} {}".format(v['description'], "(default)" if v.get("default") else ""), user_data[int(k)],
             )
 
         if value and value.get("Interlock", "OFF") == "OFF":

--- a/Util/commands.py
+++ b/Util/commands.py
@@ -17,10 +17,7 @@ commands = {
     "ButtonRetain": {
         "description": "Add MQTT retain flag on button press",
         "type": "select",
-        "parameters": {
-            "0": {"description": "Disabled", "default": "True"},
-            "1": {"description": "Enabled"},
-        },
+        "parameters": {"0": {"description": "Disabled", "default": "True"}, "1": {"description": "Enabled"},},
     },
     "ButtonTopic": {
         "description": "MQTT button topic",
@@ -55,10 +52,7 @@ commands = {
     "PowerRetain": {
         "description": "Add MQTT power retain flag on status update",
         "type": "select",
-        "parameters": {
-            "0": {"description": "Disabled", "default": "True"},
-            "1": {"description": "Enabled"},
-        },
+        "parameters": {"0": {"description": "Disabled", "default": "True"}, "1": {"description": "Enabled"},},
     },
     "PulseTime": {
         "description": "Control the relay PulseTime",
@@ -87,9 +81,6 @@ commands = {
     "SwitchRetain": {
         "description": "Add MQTT retain flag on switch press",
         "type": "select",
-        "parameters": {
-            "0": {"description": "Disabled", "default": "True"},
-            "1": {"description": "Enabled"},
-        },
+        "parameters": {"0": {"description": "Disabled", "default": "True"}, "1": {"description": "Enabled"},},
     },
 }

--- a/Util/models.py
+++ b/Util/models.py
@@ -147,13 +147,9 @@ class TasmotaDevicesModel(QAbstractTableModel):
 
             elif role == Qt.TextAlignmentRole:
                 # Left-aligned columns
-                if col_name in (
-                    "Device",
-                    "Module",
-                    "RestartReason",
-                    "OtaUrl",
-                    "Hostname",
-                ) or col_name.endswith("Topic"):
+                if col_name in ("Device", "Module", "RestartReason", "OtaUrl", "Hostname",) or col_name.endswith(
+                    "Topic"
+                ):
                     return Qt.AlignLeft | Qt.AlignVCenter | Qt.TextWordWrap
 
                 # Right-aligned columns
@@ -282,7 +278,7 @@ class DeviceDelegate(QStyledItemDelegate):
                         px = QPixmap(":/status_high.png")
 
                 px_y = (option.rect.height() - 24) / 2
-                p.drawPixmap(option.rect.x() + 2, option.rect.y() + px_y, px.scaled(24, 24))
+                p.drawPixmap(int(option.rect.x() + 2), int(option.rect.y() + px_y), px.scaled(24, 24))
 
                 p.drawText(option.rect.adjusted(28, 0, 0, 0), Qt.AlignVCenter | Qt.AlignLeft, index.data())
 
@@ -337,11 +333,10 @@ class DeviceDelegate(QStyledItemDelegate):
                         y = option.rect.y() + (option.rect.height() - 24) / 2
 
                         if num == 1:
-                            p.drawPixmap(x, y, 24, 24, QPixmap(":/P_{}".format(index.data()[k])))
+                            p.drawPixmap(int(x), int(y), 24, 24, QPixmap(":/P_{}".format(index.data()[k])))
 
                         else:
-                            p.drawPixmap(x, y, 24, 24, QPixmap(":/P{}_{}".format(i + 1, index.data()[k])))
-
+                            p.drawPixmap(int(x), int(y), 24, 24, QPixmap(":/P{}_{}".format(i + 1, index.data()[k])))
                 else:
                     i = 0
                     for row in range(2):
@@ -351,8 +346,8 @@ class DeviceDelegate(QStyledItemDelegate):
 
                             if i < num:
                                 p.drawPixmap(
-                                    x,
-                                    y,
+                                    int(x),
+                                    int(y),
                                     24,
                                     24,
                                     QPixmap(":/P{}_{}".format(i + 1, list(index.data().values())[i])),

--- a/Util/setoptions.py
+++ b/Util/setoptions.py
@@ -2,26 +2,17 @@ setoptions = {
     "0": {
         "description": "Save power state and use after restart",
         "type": "select",
-        "parameters": {
-            "0": {"description": "Disabled"},
-            "1": {"description": "Enabled", "default": "True"},
-        },
+        "parameters": {"0": {"description": "Disabled"}, "1": {"description": "Enabled", "default": "True"},},
     },
     "1": {
         "description": "Set button multipress mode",
         "type": "select",
-        "parameters": {
-            "0": {"description": "Disabled"},
-            "1": {"description": "Enabled", "default": "True"},
-        },
+        "parameters": {"0": {"description": "Disabled"}, "1": {"description": "Enabled", "default": "True"},},
     },
     "11": {
         "description": "Swap button single and double press functionality",
         "type": "select",
-        "parameters": {
-            "0": {"description": "Disabled", "default": "True"},
-            "1": {"description": "Enabled"},
-        },
+        "parameters": {"0": {"description": "Disabled", "default": "True"}, "1": {"description": "Enabled"},},
     },
     "13": {
         "description": "Allow immediate action on single button press",
@@ -52,17 +43,11 @@ setoptions = {
     "61": {
         "description": "Force local operation when ButtonTopic or SwitchTopic is set",
         "type": "select",
-        "parameters": {
-            "0": {"description": "Disabled", "default": "True"},
-            "1": {"description": "Enabled"},
-        },
+        "parameters": {"0": {"description": "Disabled", "default": "True"}, "1": {"description": "Enabled"},},
     },
     "63": {
         "description": "Scan relay power feedback state at restart",
         "type": "select",
-        "parameters": {
-            "0": {"description": "Enabled", "default": "True"},
-            "1": {"description": "Disabled"},
-        },
+        "parameters": {"0": {"description": "Enabled", "default": "True"}, "1": {"description": "Disabled"},},
     },
 }

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,7 @@ long_description = "{}\n\n# Changelog\n{}".format(readme, changelog)
 
 if os.name == "nt":
     scripts = None
-    entry_points = {
-        {
-            'console_scripts': ['tdmgr=tdmgr:main'],
-        }
-    }
+    entry_points = {{'console_scripts': ['tdmgr=tdmgr:main'],}}
 else:
     scripts = ['tdmgr.py']
     entry_points = None

--- a/tdmgr.py
+++ b/tdmgr.py
@@ -95,9 +95,7 @@ class MainWindow(QMainWindow):
         for mac in self.devices.childGroups():
             self.devices.beginGroup(mac)
             device = TasmotaDevice(
-                self.devices.value("topic"),
-                self.devices.value("full_topic"),
-                self.devices.value("device_name"),
+                self.devices.value("topic"), self.devices.value("full_topic"), self.devices.value("device_name"),
             )
             device.debug = self.devices.value("debug", False, bool)
             device.p['Mac'] = mac.replace("-", ":")
@@ -275,9 +273,7 @@ class MainWindow(QMainWindow):
         self.actToggleConnect.setText("Disconnect")
         self.statusBar().showMessage(
             "Connected to {}:{} as {}".format(
-                self.broker_hostname,
-                self.broker_port,
-                self.broker_username if self.broker_username else '[anonymous]',
+                self.broker_hostname, self.broker_port, self.broker_username if self.broker_username else '[anonymous]',
             )
         )
 
@@ -371,8 +367,7 @@ class MainWindow(QMainWindow):
 
                 for p in default_patterns + custom_patterns:
                     match = re.fullmatch(
-                        p.replace("%topic%", "(?P<topic>.*?)").replace("%prefix%", "(?P<prefix>.*?)") + ".*$",
-                        topic,
+                        p.replace("%topic%", "(?P<topic>.*?)").replace("%prefix%", "(?P<prefix>.*?)") + ".*$", topic,
                     )
                     if match:
                         # assume that the matched topic is the one configured in device settings
@@ -385,8 +380,7 @@ class MainWindow(QMainWindow):
                                 p.replace("%prefix%", "cmnd").replace("%topic%", possible_topic) + "FullTopic"
                             )
                             logging.debug(
-                                "DISCOVERY: Asking an unknown device for FullTopic at %s",
-                                possible_topic_cmnd,
+                                "DISCOVERY: Asking an unknown device for FullTopic at %s", possible_topic_cmnd,
                             )
                             self.mqtt_queue.append([possible_topic_cmnd, ""])
 
@@ -407,9 +401,7 @@ class MainWindow(QMainWindow):
                             d.update_property("FullTopic", full_topic)
                         else:
                             logging.info(
-                                "DISCOVERY: Discovered topic=%s with fulltopic=%s",
-                                parsed['topic'],
-                                full_topic,
+                                "DISCOVERY: Discovered topic=%s with fulltopic=%s", parsed['topic'], full_topic,
                             )
                             d = TasmotaDevice(parsed['topic'], full_topic)
                             self.env.devices.append(d)
@@ -519,11 +511,7 @@ class MainWindow(QMainWindow):
     def auto_telemetry_period(self):
         curr_val = self.settings.value("autotelemetry", 5000, int)
         period, ok = QInputDialog.getInt(
-            self,
-            "Set AutoTelemetry period",
-            "Values under 5000ms may cause increased ESP LoadAvg",
-            curr_val,
-            1000,
+            self, "Set AutoTelemetry period", "Values under 5000ms may cause increased ESP LoadAvg", curr_val, 1000,
         )
         if ok:
             self.settings.setValue("autotelemetry", period)


### PR DESCRIPTION
This change allows tdmgr to run with Python 3.10 (tested with 3.10.0).

It appears that QPainter.drawPixmap() now requires ints not floats. Casting to int allows the application to start and run as expected.

Original PR : https://github.com/jziolkowski/tdm/pull/184