### PR TITLE
Allow user to use custom location for config and logging

### DIFF
--- a/GUI/console.py
+++ b/GUI/console.py
@@ -5,7 +5,6 @@ from PyQt5.QtCore import (
     QDir,
     QEvent,
     QRegExp,
-    QSettings,
     QSize,
     QStringListModel,
     Qt,
@@ -36,13 +35,13 @@ class ConsoleWidget(QDockWidget):
 
     sendCommand = pyqtSignal(str, str)
 
-    def __init__(self, device, *args, **kwargs):
+    def __init__(self, settings, device, *args, **kwargs):
         super().__init__()
         self.setAllowedAreas(Qt.BottomDockWidgetArea)
         self.setWindowTitle(f"Console [{device.name}]")
         self.device = device
 
-        self.settings = QSettings(QSettings.IniFormat, QSettings.UserScope, "tdm", "tdm")
+        self.settings = settings
 
         console_font_size = self.settings.value("console_font_size", 9, int)
         console_font.setPointSize(console_font_size)

--- a/GUI/devices.py
+++ b/GUI/devices.py
@@ -1,7 +1,7 @@
 import os
 from json import dumps
 
-from PyQt5.QtCore import QDir, QSettings, QSortFilterProxyModel, Qt, QUrl, pyqtSignal
+from PyQt5.QtCore import QDir, QSortFilterProxyModel, Qt, QUrl, pyqtSignal
 from PyQt5.QtGui import QColor, QIcon
 from PyQt5.QtNetwork import QNetworkAccessManager, QNetworkRequest
 from PyQt5.QtWidgets import (
@@ -60,7 +60,7 @@ class DevicesListWidget(QWidget):
         self.nam = QNetworkAccessManager()
         self.backup = bytes()
 
-        self.settings = QSettings(QSettings.IniFormat, QSettings.UserScope, "tdm", "tdm")
+        self.settings = parent.settings
         views_order = self.settings.value("views_order", [])
 
         self.views = {}

--- a/GUI/dialogs/broker.py
+++ b/GUI/dialogs/broker.py
@@ -2,7 +2,6 @@ import random
 import ssl
 import string
 
-from PyQt5.QtCore import QSettings
 from PyQt5.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -17,12 +16,12 @@ from GUI.widgets import HLayout, SpinBox, VLayout
 
 
 class BrokerDialog(QDialog):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, settings, *args, **kwargs):
         super(BrokerDialog, self).__init__(*args, **kwargs)
 
         self.setWindowTitle("MQTT Broker")
 
-        self.settings = QSettings(QSettings.IniFormat, QSettings.UserScope, "tdm", "tdm")
+        self.settings = settings
 
         gbtls = QGroupBox(" TLS [optional]")
         tlsLayout = QFormLayout()

--- a/GUI/dialogs/bssid.py
+++ b/GUI/dialogs/bssid.py
@@ -1,17 +1,16 @@
-from PyQt5.QtCore import QSettings
 from PyQt5.QtWidgets import QDialog, QHeaderView, QPushButton, QTableWidget, QTableWidgetItem
 
 from GUI.widgets import HLayout, VLayout
 
 
 class BSSIdDialog(QDialog):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, settings, *args, **kwargs):
         super(BSSIdDialog, self).__init__(*args, **kwargs)
         self.setMinimumHeight(400)
         self.setMinimumWidth(400)
         self.setWindowTitle("BSSId aliases")
 
-        self.settings = QSettings(QSettings.IniFormat, QSettings.UserScope, "tdm", "tdm")
+        self.settings = settings
         self.settings.beginGroup("BSSId")
 
         vl = VLayout()

--- a/GUI/dialogs/patterns.py
+++ b/GUI/dialogs/patterns.py
@@ -1,4 +1,3 @@
-from PyQt5.QtCore import QSettings
 from PyQt5.QtWidgets import (
     QDialog,
     QHeaderView,
@@ -12,13 +11,13 @@ from GUI.widgets import HLayout, VLayout
 
 
 class PatternsDialog(QDialog):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, settings, *args, **kwargs):
         super(PatternsDialog, self).__init__(*args, **kwargs)
         self.setMinimumHeight(400)
         self.setMinimumWidth(400)
         self.setWindowTitle("Autodiscovery patterns")
 
-        self.settings = QSettings(QSettings.IniFormat, QSettings.UserScope, "tdm", "tdm")
+        self.settings = settings
         self.settings.beginGroup("Patterns")
 
         vl = VLayout()

--- a/GUI/dialogs/prefs.py
+++ b/GUI/dialogs/prefs.py
@@ -1,16 +1,16 @@
-from PyQt5.QtCore import QSettings, Qt
+from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QCheckBox, QDialog, QDialogButtonBox, QFormLayout, QGroupBox
 
 from GUI.widgets import SpinBox, VLayout
 
 
 class PrefsDialog(QDialog):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, settings, *args, **kwargs):
         super(PrefsDialog, self).__init__(*args, **kwargs)
         self.setWindowTitle("Preferences")
         # self.setMinimumSize(QSize(300, 200))
 
-        self.settings = QSettings(QSettings.IniFormat, QSettings.UserScope, "tdm", "tdm")
+        self.settings = settings
 
         self.devices_short_version = self.settings.value("devices_short_version", True, bool)
 

--- a/models/devices.py
+++ b/models/devices.py
@@ -1,14 +1,14 @@
-from PyQt5.QtCore import QAbstractTableModel, QModelIndex, QSettings, Qt
+from PyQt5.QtCore import QAbstractTableModel, QModelIndex, Qt
 
 from models.common import DeviceRoles
 from Util import TasmotaDevice
 
 
 class TasmotaDevicesModel(QAbstractTableModel):
-    def __init__(self, tasmota_env):
+    def __init__(self, settings, devices, tasmota_env):
         super().__init__()
-        self.settings = QSettings(QSettings.IniFormat, QSettings.UserScope, "tdm", "tdm")
-        self.devices = QSettings(QSettings.IniFormat, QSettings.UserScope, "tdm", "devices")
+        self.settings = settings
+        self.devices = devices
         self.tasmota_env = tasmota_env
         self.columns = []
 


### PR DESCRIPTION
TDM has now a few command-line args:

--debug (the same as settings debug=1 in tdm.cfg; now deprecated)
--config-location: path to *directory* where to store tdm.cfg and devices.cfg
--log-location: path to *directory* where to store tdm.log
--local: shorthand to `--config location .` and `--log-location .`, meaning that TDM will read/save files in the current directory

Also now by default logging is also printed to stdout

closes #215