### PR TITLE
Support paho_mqtt >= 2, fixes #267

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-paho_mqtt>=1.4,<2
+paho_mqtt>=1.4
 PyQt5>=5.14.2,<6
 pydantic==2.5.2

--- a/tdmgr/mqtt.py
+++ b/tdmgr/mqtt.py
@@ -112,6 +112,7 @@ class MqttClient(QObject):
 
     MQTT_3_1 = mqtt.MQTTv31
     MQTT_3_1_1 = mqtt.MQTTv311
+    MQTT_5 = mqtt.MQTTv5
 
     connected = pyqtSignal()
     connecting = pyqtSignal()
@@ -143,9 +144,16 @@ class MqttClient(QObject):
 
         self.m_state = MqttClient.Disconnected
 
-        self.m_client = mqtt.Client(
-            clean_session=self.m_cleanSession, protocol=self.protocolVersion
-        )
+        if hasattr(mqtt, 'CallbackAPIVersion'):
+            self.m_protocolVersion = MqttClient.MQTT_5
+            self.m_client = mqtt.Client(
+                callback_api_version=mqtt.CallbackAPIVersion.VERSION2, protocol=self.protocolVersion
+            )
+        else:
+            self.m_protocolVersion = MqttClient.MQTT_3_1
+            self.m_client = mqtt.Client(
+                clean_session=self.m_cleanSession, protocol=self.protocolVersion
+            )
 
         self.m_client.on_connect = self.on_connect
         self.m_client.on_message = self.on_message
@@ -217,7 +225,7 @@ class MqttClient(QObject):
     def protocolVersion(self, protocolVersion):
         if self.m_protocolVersion == protocolVersion:
             return
-        if protocolVersion in (MqttClient.MQTT_3_1, MqttClient.MQTT_3_1_1):
+        if protocolVersion in (MqttClient.MQTT_3_1, MqttClient.MQTT_3_1_1, MqttClient.MQTT_5):
             self.m_protocolVersion = protocolVersion
             self.protocolVersionChanged.emit(protocolVersion)
 


### PR DESCRIPTION
With these code changes all versions of paho_mqtt >= 1.4 including 2.x are support. Please consider setting `paho_mqtt>=2.1.0` in `requirements.txt` to benefit from the many improvements.